### PR TITLE
Publish EyesLibrary docs to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,51 @@
+name: Build and publish docs
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out project
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Generate EyesLibrary docs
+        run: |
+          mkdir -p _site
+          python -m robot.libdoc EyesLibrary _site/index.html
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,7 @@ dmypy.json
 log.html
 output.xml
 report.html
+
+# Generated docs site
+_site/
+.docs-venv/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 eyes-robotframework==6.4.41
-robotframework==6.1
-robotframework-seleniumlibrary==6.1.0
+robotframework==7.4.2
+robotframework-seleniumlibrary==6.9.0
 selenium==4.44.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-eyes-robotframework==5.12.0
+eyes-robotframework==6.4.41
 robotframework==6.1
 robotframework-seleniumlibrary==6.1.0
-selenium==4.9.1
+selenium==4.44.0


### PR DESCRIPTION
Add docs workflow that generates the EyesLibrary keyword reference via robot.libdoc and deploys it to GitHub Pages on every push to main. Bump eyes-robotframework to 6.4.41 (and selenium to 4.44.0 to satisfy the new transitive Appium dependency).